### PR TITLE
Fix parse_skipped for parsing zeroes

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 use ::core::fmt;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq)]
 pub enum AtoiSimdError<'a> {
     Empty,
     Size(usize, &'a [u8]),

--- a/src/linker/mod.rs
+++ b/src/linker/mod.rs
@@ -73,7 +73,7 @@ pub trait Parser<T: ParserPos<T>>: Sized {
         if *s.first().ok_or(AtoiSimdError::Empty)? == b'+' {
             i = 1;
         }
-        while s.len() > i {
+        while i + 1 < s.len() {
             if *s.get_safe_unchecked(i) != b'0' {
                 break;
             }
@@ -120,7 +120,7 @@ fn atoi_simd_parse_skipped_signed<T: ParserPos<T> + ParserNeg<T>>(
         }
         _ => {}
     };
-    while s.len() > i {
+    while i + 1 < s.len() {
         if *s.get_safe_unchecked(i) != b'0' {
             break;
         }

--- a/src/test.rs
+++ b/src/test.rs
@@ -1102,4 +1102,46 @@ fn test_parse_skipped() {
 
     let tmp = parse_skipped::<i128>(b"-000000000000000000000000012345678901234567890").unwrap();
     assert_eq!(tmp, -12345678901234567890_i128);
+    
+    // Zeroes.
+    assert_eq!(parse_skipped::<i8>(b"0"), Ok(0));
+    assert_eq!(parse_skipped::<i8>(b"-0"), Ok(0));
+    assert_eq!(parse_skipped::<i8>(b"-0000000000000000000000000000"), Ok(0));
+    assert_eq!(parse_skipped::<i8>(b"+0"), Ok(0));
+    assert_eq!(parse_skipped::<i8>(b"+0000000000000000000000000000"), Ok(0));
+    assert_eq!(parse_skipped::<u8>(b"0"), Ok(0));
+    assert_eq!(parse_skipped::<u8>(b"+0"), Ok(0));
+    assert_eq!(parse_skipped::<u8>(b"+0000000000000000000000000000"), Ok(0));
+    assert_eq!(parse_skipped::<i16>(b"0"), Ok(0));
+    assert_eq!(parse_skipped::<i16>(b"-0"), Ok(0));
+    assert_eq!(parse_skipped::<i16>(b"-0000000000000000000000000000"), Ok(0));
+    assert_eq!(parse_skipped::<i16>(b"+0"), Ok(0));
+    assert_eq!(parse_skipped::<i16>(b"+0000000000000000000000000000"), Ok(0));
+    assert_eq!(parse_skipped::<u16>(b"0"), Ok(0));
+    assert_eq!(parse_skipped::<u16>(b"+0"), Ok(0));
+    assert_eq!(parse_skipped::<u16>(b"+0000000000000000000000000000"), Ok(0));
+    assert_eq!(parse_skipped::<i32>(b"0"), Ok(0));
+    assert_eq!(parse_skipped::<i32>(b"-0"), Ok(0));
+    assert_eq!(parse_skipped::<i32>(b"-0000000000000000000000000000"), Ok(0));
+    assert_eq!(parse_skipped::<i32>(b"+0"), Ok(0));
+    assert_eq!(parse_skipped::<i32>(b"+0000000000000000000000000000"), Ok(0));
+    assert_eq!(parse_skipped::<u32>(b"0"), Ok(0));
+    assert_eq!(parse_skipped::<u32>(b"+0"), Ok(0));
+    assert_eq!(parse_skipped::<u32>(b"+0000000000000000000000000000"), Ok(0));
+    assert_eq!(parse_skipped::<i64>(b"0"), Ok(0));
+    assert_eq!(parse_skipped::<i64>(b"-0"), Ok(0));
+    assert_eq!(parse_skipped::<i64>(b"-0000000000000000000000000000"), Ok(0));
+    assert_eq!(parse_skipped::<i64>(b"+0"), Ok(0));
+    assert_eq!(parse_skipped::<i64>(b"+0000000000000000000000000000"), Ok(0));
+    assert_eq!(parse_skipped::<u64>(b"0"), Ok(0));
+    assert_eq!(parse_skipped::<u64>(b"+0"), Ok(0));
+    assert_eq!(parse_skipped::<u64>(b"+0000000000000000000000000000"), Ok(0));
+    assert_eq!(parse_skipped::<i128>(b"0"), Ok(0));
+    assert_eq!(parse_skipped::<i128>(b"-0"), Ok(0));
+    assert_eq!(parse_skipped::<i128>(b"-0000000000000000000000000000"), Ok(0));
+    assert_eq!(parse_skipped::<i128>(b"+0"), Ok(0));
+    assert_eq!(parse_skipped::<i128>(b"+0000000000000000000000000000"), Ok(0));
+    assert_eq!(parse_skipped::<u128>(b"0"), Ok(0));
+    assert_eq!(parse_skipped::<u128>(b"+0"), Ok(0));
+    assert_eq!(parse_skipped::<u128>(b"+0000000000000000000000000000"), Ok(0));
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -1102,7 +1102,7 @@ fn test_parse_skipped() {
 
     let tmp = parse_skipped::<i128>(b"-000000000000000000000000012345678901234567890").unwrap();
     assert_eq!(tmp, -12345678901234567890_i128);
-    
+
     // Zeroes.
     assert_eq!(parse_skipped::<i8>(b"0"), Ok(0));
     assert_eq!(parse_skipped::<i8>(b"-0"), Ok(0));
@@ -1114,34 +1114,70 @@ fn test_parse_skipped() {
     assert_eq!(parse_skipped::<u8>(b"+0000000000000000000000000000"), Ok(0));
     assert_eq!(parse_skipped::<i16>(b"0"), Ok(0));
     assert_eq!(parse_skipped::<i16>(b"-0"), Ok(0));
-    assert_eq!(parse_skipped::<i16>(b"-0000000000000000000000000000"), Ok(0));
+    assert_eq!(
+        parse_skipped::<i16>(b"-0000000000000000000000000000"),
+        Ok(0)
+    );
     assert_eq!(parse_skipped::<i16>(b"+0"), Ok(0));
-    assert_eq!(parse_skipped::<i16>(b"+0000000000000000000000000000"), Ok(0));
+    assert_eq!(
+        parse_skipped::<i16>(b"+0000000000000000000000000000"),
+        Ok(0)
+    );
     assert_eq!(parse_skipped::<u16>(b"0"), Ok(0));
     assert_eq!(parse_skipped::<u16>(b"+0"), Ok(0));
-    assert_eq!(parse_skipped::<u16>(b"+0000000000000000000000000000"), Ok(0));
+    assert_eq!(
+        parse_skipped::<u16>(b"+0000000000000000000000000000"),
+        Ok(0)
+    );
     assert_eq!(parse_skipped::<i32>(b"0"), Ok(0));
     assert_eq!(parse_skipped::<i32>(b"-0"), Ok(0));
-    assert_eq!(parse_skipped::<i32>(b"-0000000000000000000000000000"), Ok(0));
+    assert_eq!(
+        parse_skipped::<i32>(b"-0000000000000000000000000000"),
+        Ok(0)
+    );
     assert_eq!(parse_skipped::<i32>(b"+0"), Ok(0));
-    assert_eq!(parse_skipped::<i32>(b"+0000000000000000000000000000"), Ok(0));
+    assert_eq!(
+        parse_skipped::<i32>(b"+0000000000000000000000000000"),
+        Ok(0)
+    );
     assert_eq!(parse_skipped::<u32>(b"0"), Ok(0));
     assert_eq!(parse_skipped::<u32>(b"+0"), Ok(0));
-    assert_eq!(parse_skipped::<u32>(b"+0000000000000000000000000000"), Ok(0));
+    assert_eq!(
+        parse_skipped::<u32>(b"+0000000000000000000000000000"),
+        Ok(0)
+    );
     assert_eq!(parse_skipped::<i64>(b"0"), Ok(0));
     assert_eq!(parse_skipped::<i64>(b"-0"), Ok(0));
-    assert_eq!(parse_skipped::<i64>(b"-0000000000000000000000000000"), Ok(0));
+    assert_eq!(
+        parse_skipped::<i64>(b"-0000000000000000000000000000"),
+        Ok(0)
+    );
     assert_eq!(parse_skipped::<i64>(b"+0"), Ok(0));
-    assert_eq!(parse_skipped::<i64>(b"+0000000000000000000000000000"), Ok(0));
+    assert_eq!(
+        parse_skipped::<i64>(b"+0000000000000000000000000000"),
+        Ok(0)
+    );
     assert_eq!(parse_skipped::<u64>(b"0"), Ok(0));
     assert_eq!(parse_skipped::<u64>(b"+0"), Ok(0));
-    assert_eq!(parse_skipped::<u64>(b"+0000000000000000000000000000"), Ok(0));
+    assert_eq!(
+        parse_skipped::<u64>(b"+0000000000000000000000000000"),
+        Ok(0)
+    );
     assert_eq!(parse_skipped::<i128>(b"0"), Ok(0));
     assert_eq!(parse_skipped::<i128>(b"-0"), Ok(0));
-    assert_eq!(parse_skipped::<i128>(b"-0000000000000000000000000000"), Ok(0));
+    assert_eq!(
+        parse_skipped::<i128>(b"-0000000000000000000000000000"),
+        Ok(0)
+    );
     assert_eq!(parse_skipped::<i128>(b"+0"), Ok(0));
-    assert_eq!(parse_skipped::<i128>(b"+0000000000000000000000000000"), Ok(0));
+    assert_eq!(
+        parse_skipped::<i128>(b"+0000000000000000000000000000"),
+        Ok(0)
+    );
     assert_eq!(parse_skipped::<u128>(b"0"), Ok(0));
     assert_eq!(parse_skipped::<u128>(b"+0"), Ok(0));
-    assert_eq!(parse_skipped::<u128>(b"+0000000000000000000000000000"), Ok(0));
+    assert_eq!(
+        parse_skipped::<u128>(b"+0000000000000000000000000000"),
+        Ok(0)
+    );
 }


### PR DESCRIPTION
Fixes https://github.com/RoDmitry/atoi_simd/issues/9.