### PR TITLE
Some cleanup/refactor of `Parser…` trait bounds

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,30 +68,30 @@ mod simd;
 mod test;
 
 pub use crate::error::AtoiSimdError;
-use crate::linker::{Parser, ParserNeg, ParserPos};
+use crate::linker::{Parse, ParseNeg, ParsePos};
 
 /// Parses slice of digits, and checks first '-' char for signed integers.
 #[inline]
-pub fn parse<T: Parser + ParserPos>(s: &[u8]) -> Result<T, AtoiSimdError> {
+pub fn parse<T: Parse + ParsePos>(s: &[u8]) -> Result<T, AtoiSimdError> {
     T::atoi_simd_parse(s)
 }
 
 /// Parses positive integer.
 #[inline]
-pub fn parse_pos<T: ParserPos>(s: &[u8]) -> Result<T, AtoiSimdError> {
+pub fn parse_pos<T: ParsePos>(s: &[u8]) -> Result<T, AtoiSimdError> {
     T::atoi_simd_parse_pos(s)
 }
 
 /// Parses negative integer. Slice must not contain '-' sign.
 #[inline]
-pub fn parse_neg<T: ParserNeg>(s: &[u8]) -> Result<T, AtoiSimdError> {
+pub fn parse_neg<T: ParseNeg>(s: &[u8]) -> Result<T, AtoiSimdError> {
     T::atoi_simd_parse_neg(s)
 }
 
 /// Parses slice of digits until it reaches invalid character, and checks first '-' char for signed integers.
 /// Returns parsed value and parsed size of the slice.
 #[inline]
-pub fn parse_until_invalid<T: Parser + ParserPos>(
+pub fn parse_until_invalid<T: Parse + ParsePos>(
     s: &[u8],
 ) -> Result<(T, usize), AtoiSimdError> {
     T::atoi_simd_parse_until_invalid(s)
@@ -100,14 +100,14 @@ pub fn parse_until_invalid<T: Parser + ParserPos>(
 /// Parses positive integer until it reaches invalid character.
 /// Returns parsed value and parsed size of the slice.
 #[inline]
-pub fn parse_until_invalid_pos<T: ParserPos>(s: &[u8]) -> Result<(T, usize), AtoiSimdError> {
+pub fn parse_until_invalid_pos<T: ParsePos>(s: &[u8]) -> Result<(T, usize), AtoiSimdError> {
     T::atoi_simd_parse_until_invalid_pos(s)
 }
 
 /// Parses negative integer until it reaches invalid character. Slice must not contain '-' sign.
 /// Returns parsed value and parsed size of the slice.
 #[inline]
-pub fn parse_until_invalid_neg<T: ParserNeg>(s: &[u8]) -> Result<(T, usize), AtoiSimdError> {
+pub fn parse_until_invalid_neg<T: ParseNeg>(s: &[u8]) -> Result<(T, usize), AtoiSimdError> {
     T::atoi_simd_parse_until_invalid_neg(s)
 }
 
@@ -116,6 +116,6 @@ pub fn parse_until_invalid_neg<T: ParserNeg>(s: &[u8]) -> Result<(T, usize), Ato
 /// Skips '+' char and extra zeroes at the beginning.
 /// It's slower than `parse()`.
 #[inline]
-pub fn parse_skipped<T: Parser + ParserPos>(s: &[u8]) -> Result<T, AtoiSimdError> {
+pub fn parse_skipped<T: Parse + ParsePos>(s: &[u8]) -> Result<T, AtoiSimdError> {
     T::atoi_simd_parse_skipped(s)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,9 +91,7 @@ pub fn parse_neg<T: ParseNeg>(s: &[u8]) -> Result<T, AtoiSimdError> {
 /// Parses slice of digits until it reaches invalid character, and checks first '-' char for signed integers.
 /// Returns parsed value and parsed size of the slice.
 #[inline]
-pub fn parse_until_invalid<T: Parse>(
-    s: &[u8],
-) -> Result<(T, usize), AtoiSimdError> {
+pub fn parse_until_invalid<T: Parse>(s: &[u8]) -> Result<(T, usize), AtoiSimdError> {
     T::atoi_simd_parse_until_invalid(s)
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,7 @@ mod simd;
 mod test;
 
 pub use crate::error::AtoiSimdError;
-use crate::linker::{Parse, ParseNeg, ParsePos};
+use crate::linker::{Parse, ParseNeg};
 
 /// Parses slice of digits, and checks first '-' char for signed integers.
 #[inline]
@@ -78,7 +78,7 @@ pub fn parse<T: Parse>(s: &[u8]) -> Result<T, AtoiSimdError> {
 
 /// Parses positive integer.
 #[inline]
-pub fn parse_pos<T: ParsePos>(s: &[u8]) -> Result<T, AtoiSimdError> {
+pub fn parse_pos<T: Parse>(s: &[u8]) -> Result<T, AtoiSimdError> {
     T::atoi_simd_parse_pos(s)
 }
 
@@ -100,7 +100,7 @@ pub fn parse_until_invalid<T: Parse>(
 /// Parses positive integer until it reaches invalid character.
 /// Returns parsed value and parsed size of the slice.
 #[inline]
-pub fn parse_until_invalid_pos<T: ParsePos>(s: &[u8]) -> Result<(T, usize), AtoiSimdError> {
+pub fn parse_until_invalid_pos<T: Parse>(s: &[u8]) -> Result<(T, usize), AtoiSimdError> {
     T::atoi_simd_parse_until_invalid_pos(s)
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,26 +72,26 @@ use crate::linker::{Parser, ParserNeg, ParserPos};
 
 /// Parses slice of digits, and checks first '-' char for signed integers.
 #[inline]
-pub fn parse<T: Parser<T> + ParserPos<T>>(s: &[u8]) -> Result<T, AtoiSimdError> {
+pub fn parse<T: Parser + ParserPos>(s: &[u8]) -> Result<T, AtoiSimdError> {
     T::atoi_simd_parse(s)
 }
 
 /// Parses positive integer.
 #[inline]
-pub fn parse_pos<T: ParserPos<T>>(s: &[u8]) -> Result<T, AtoiSimdError> {
+pub fn parse_pos<T: ParserPos>(s: &[u8]) -> Result<T, AtoiSimdError> {
     T::atoi_simd_parse_pos(s)
 }
 
 /// Parses negative integer. Slice must not contain '-' sign.
 #[inline]
-pub fn parse_neg<T: ParserNeg<T>>(s: &[u8]) -> Result<T, AtoiSimdError> {
+pub fn parse_neg<T: ParserNeg>(s: &[u8]) -> Result<T, AtoiSimdError> {
     T::atoi_simd_parse_neg(s)
 }
 
 /// Parses slice of digits until it reaches invalid character, and checks first '-' char for signed integers.
 /// Returns parsed value and parsed size of the slice.
 #[inline]
-pub fn parse_until_invalid<T: Parser<T> + ParserPos<T>>(
+pub fn parse_until_invalid<T: Parser + ParserPos>(
     s: &[u8],
 ) -> Result<(T, usize), AtoiSimdError> {
     T::atoi_simd_parse_until_invalid(s)
@@ -100,14 +100,14 @@ pub fn parse_until_invalid<T: Parser<T> + ParserPos<T>>(
 /// Parses positive integer until it reaches invalid character.
 /// Returns parsed value and parsed size of the slice.
 #[inline]
-pub fn parse_until_invalid_pos<T: ParserPos<T>>(s: &[u8]) -> Result<(T, usize), AtoiSimdError> {
+pub fn parse_until_invalid_pos<T: ParserPos>(s: &[u8]) -> Result<(T, usize), AtoiSimdError> {
     T::atoi_simd_parse_until_invalid_pos(s)
 }
 
 /// Parses negative integer until it reaches invalid character. Slice must not contain '-' sign.
 /// Returns parsed value and parsed size of the slice.
 #[inline]
-pub fn parse_until_invalid_neg<T: ParserNeg<T>>(s: &[u8]) -> Result<(T, usize), AtoiSimdError> {
+pub fn parse_until_invalid_neg<T: ParserNeg>(s: &[u8]) -> Result<(T, usize), AtoiSimdError> {
     T::atoi_simd_parse_until_invalid_neg(s)
 }
 
@@ -116,6 +116,6 @@ pub fn parse_until_invalid_neg<T: ParserNeg<T>>(s: &[u8]) -> Result<(T, usize), 
 /// Skips '+' char and extra zeroes at the beginning.
 /// It's slower than `parse()`.
 #[inline]
-pub fn parse_skipped<T: Parser<T> + ParserPos<T>>(s: &[u8]) -> Result<T, AtoiSimdError> {
+pub fn parse_skipped<T: Parser + ParserPos>(s: &[u8]) -> Result<T, AtoiSimdError> {
     T::atoi_simd_parse_skipped(s)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@ use crate::linker::{Parse, ParseNeg, ParsePos};
 
 /// Parses slice of digits, and checks first '-' char for signed integers.
 #[inline]
-pub fn parse<T: Parse + ParsePos>(s: &[u8]) -> Result<T, AtoiSimdError> {
+pub fn parse<T: Parse>(s: &[u8]) -> Result<T, AtoiSimdError> {
     T::atoi_simd_parse(s)
 }
 
@@ -91,7 +91,7 @@ pub fn parse_neg<T: ParseNeg>(s: &[u8]) -> Result<T, AtoiSimdError> {
 /// Parses slice of digits until it reaches invalid character, and checks first '-' char for signed integers.
 /// Returns parsed value and parsed size of the slice.
 #[inline]
-pub fn parse_until_invalid<T: Parse + ParsePos>(
+pub fn parse_until_invalid<T: Parse>(
     s: &[u8],
 ) -> Result<(T, usize), AtoiSimdError> {
     T::atoi_simd_parse_until_invalid(s)
@@ -116,6 +116,6 @@ pub fn parse_until_invalid_neg<T: ParseNeg>(s: &[u8]) -> Result<(T, usize), Atoi
 /// Skips '+' char and extra zeroes at the beginning.
 /// It's slower than `parse()`.
 #[inline]
-pub fn parse_skipped<T: Parse + ParsePos>(s: &[u8]) -> Result<T, AtoiSimdError> {
+pub fn parse_skipped<T: Parse>(s: &[u8]) -> Result<T, AtoiSimdError> {
     T::atoi_simd_parse_skipped(s)
 }

--- a/src/linker/fb_32.rs
+++ b/src/linker/fb_32.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::fallback::*;
 
-impl ParserPos<u8> for u8 {
+impl ParserPos for u8 {
     #[inline(always)]
     fn atoi_simd_parse_pos(s: &[u8]) -> Result<u8, AtoiSimdError> {
         parse_fb_checked_pos::<{ u8::MAX as u64 }>(s).map(|v| v as u8)
@@ -13,7 +13,7 @@ impl ParserPos<u8> for u8 {
     }
 }
 
-impl ParserPos<i8> for i8 {
+impl ParserPos for i8 {
     #[inline(always)]
     fn atoi_simd_parse_pos(s: &[u8]) -> Result<i8, AtoiSimdError> {
         parse_fb_checked_pos::<{ i8::MAX as u64 }>(s).map(|v| v as i8)
@@ -25,7 +25,7 @@ impl ParserPos<i8> for i8 {
     }
 }
 
-impl ParserNeg<i8> for i8 {
+impl ParserNeg for i8 {
     #[inline(always)]
     fn atoi_simd_parse_neg(s: &[u8]) -> Result<i8, AtoiSimdError> {
         parse_fb_checked_neg::<{ i8::MIN as i64 }>(s).map(|v| v as i8)
@@ -37,7 +37,7 @@ impl ParserNeg<i8> for i8 {
     }
 }
 
-impl ParserPos<u16> for u16 {
+impl ParserPos for u16 {
     #[inline(always)]
     fn atoi_simd_parse_pos(s: &[u8]) -> Result<u16, AtoiSimdError> {
         parse_fb_checked_pos::<{ u16::MAX as u64 }>(s).map(|v| v as u16)
@@ -49,7 +49,7 @@ impl ParserPos<u16> for u16 {
     }
 }
 
-impl ParserPos<i16> for i16 {
+impl ParserPos for i16 {
     #[inline(always)]
     fn atoi_simd_parse_pos(s: &[u8]) -> Result<i16, AtoiSimdError> {
         parse_fb_checked_pos::<{ i16::MAX as u64 }>(s).map(|v| v as i16)
@@ -61,7 +61,7 @@ impl ParserPos<i16> for i16 {
     }
 }
 
-impl ParserNeg<i16> for i16 {
+impl ParserNeg for i16 {
     #[inline(always)]
     fn atoi_simd_parse_neg(s: &[u8]) -> Result<i16, AtoiSimdError> {
         parse_fb_checked_neg::<{ i16::MIN as i64 }>(s).map(|v| v as i16)
@@ -73,7 +73,7 @@ impl ParserNeg<i16> for i16 {
     }
 }
 
-impl ParserPos<u32> for u32 {
+impl ParserPos for u32 {
     #[inline(always)]
     fn atoi_simd_parse_pos(s: &[u8]) -> Result<u32, AtoiSimdError> {
         parse_fb_checked_pos::<{ u32::MAX as u64 }>(s).map(|v| v as u32)
@@ -85,7 +85,7 @@ impl ParserPos<u32> for u32 {
     }
 }
 
-impl ParserPos<i32> for i32 {
+impl ParserPos for i32 {
     #[inline(always)]
     fn atoi_simd_parse_pos(s: &[u8]) -> Result<i32, AtoiSimdError> {
         parse_fb_checked_pos::<{ i32::MAX as u64 }>(s).map(|v| v as i32)
@@ -97,7 +97,7 @@ impl ParserPos<i32> for i32 {
     }
 }
 
-impl ParserNeg<i32> for i32 {
+impl ParserNeg for i32 {
     #[inline(always)]
     fn atoi_simd_parse_neg(s: &[u8]) -> Result<i32, AtoiSimdError> {
         parse_fb_checked_neg::<{ i32::MIN as i64 }>(s).map(|v| v as i32)
@@ -110,7 +110,7 @@ impl ParserNeg<i32> for i32 {
 }
 
 #[cfg(target_pointer_width = "32")]
-impl ParserPos<usize> for usize {
+impl ParserPos for usize {
     #[inline(always)]
     fn atoi_simd_parse_pos(s: &[u8]) -> Result<usize, AtoiSimdError> {
         parse_fb_checked_pos::<{ u32::MAX as u64 }>(s).map(|v| v as usize)
@@ -123,7 +123,7 @@ impl ParserPos<usize> for usize {
 }
 
 #[cfg(target_pointer_width = "32")]
-impl ParserPos<isize> for isize {
+impl ParserPos for isize {
     #[inline(always)]
     fn atoi_simd_parse_pos(s: &[u8]) -> Result<isize, AtoiSimdError> {
         parse_fb_checked_pos::<{ i32::MAX as u64 }>(s).map(|v| v as isize)
@@ -136,7 +136,7 @@ impl ParserPos<isize> for isize {
 }
 
 #[cfg(target_pointer_width = "32")]
-impl ParserNeg<isize> for isize {
+impl ParserNeg for isize {
     #[inline(always)]
     fn atoi_simd_parse_neg(s: &[u8]) -> Result<isize, AtoiSimdError> {
         parse_fb_checked_neg::<{ i32::MIN as i64 }>(s).map(|v| v as isize)

--- a/src/linker/fb_32.rs
+++ b/src/linker/fb_32.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::fallback::*;
 
-impl ParserPos for u8 {
+impl ParsePos for u8 {
     #[inline(always)]
     fn atoi_simd_parse_pos(s: &[u8]) -> Result<u8, AtoiSimdError> {
         parse_fb_checked_pos::<{ u8::MAX as u64 }>(s).map(|v| v as u8)
@@ -13,7 +13,7 @@ impl ParserPos for u8 {
     }
 }
 
-impl ParserPos for i8 {
+impl ParsePos for i8 {
     #[inline(always)]
     fn atoi_simd_parse_pos(s: &[u8]) -> Result<i8, AtoiSimdError> {
         parse_fb_checked_pos::<{ i8::MAX as u64 }>(s).map(|v| v as i8)
@@ -25,7 +25,7 @@ impl ParserPos for i8 {
     }
 }
 
-impl ParserNeg for i8 {
+impl ParseNeg for i8 {
     #[inline(always)]
     fn atoi_simd_parse_neg(s: &[u8]) -> Result<i8, AtoiSimdError> {
         parse_fb_checked_neg::<{ i8::MIN as i64 }>(s).map(|v| v as i8)
@@ -37,7 +37,7 @@ impl ParserNeg for i8 {
     }
 }
 
-impl ParserPos for u16 {
+impl ParsePos for u16 {
     #[inline(always)]
     fn atoi_simd_parse_pos(s: &[u8]) -> Result<u16, AtoiSimdError> {
         parse_fb_checked_pos::<{ u16::MAX as u64 }>(s).map(|v| v as u16)
@@ -49,7 +49,7 @@ impl ParserPos for u16 {
     }
 }
 
-impl ParserPos for i16 {
+impl ParsePos for i16 {
     #[inline(always)]
     fn atoi_simd_parse_pos(s: &[u8]) -> Result<i16, AtoiSimdError> {
         parse_fb_checked_pos::<{ i16::MAX as u64 }>(s).map(|v| v as i16)
@@ -61,7 +61,7 @@ impl ParserPos for i16 {
     }
 }
 
-impl ParserNeg for i16 {
+impl ParseNeg for i16 {
     #[inline(always)]
     fn atoi_simd_parse_neg(s: &[u8]) -> Result<i16, AtoiSimdError> {
         parse_fb_checked_neg::<{ i16::MIN as i64 }>(s).map(|v| v as i16)
@@ -73,7 +73,7 @@ impl ParserNeg for i16 {
     }
 }
 
-impl ParserPos for u32 {
+impl ParsePos for u32 {
     #[inline(always)]
     fn atoi_simd_parse_pos(s: &[u8]) -> Result<u32, AtoiSimdError> {
         parse_fb_checked_pos::<{ u32::MAX as u64 }>(s).map(|v| v as u32)
@@ -85,7 +85,7 @@ impl ParserPos for u32 {
     }
 }
 
-impl ParserPos for i32 {
+impl ParsePos for i32 {
     #[inline(always)]
     fn atoi_simd_parse_pos(s: &[u8]) -> Result<i32, AtoiSimdError> {
         parse_fb_checked_pos::<{ i32::MAX as u64 }>(s).map(|v| v as i32)
@@ -97,7 +97,7 @@ impl ParserPos for i32 {
     }
 }
 
-impl ParserNeg for i32 {
+impl ParseNeg for i32 {
     #[inline(always)]
     fn atoi_simd_parse_neg(s: &[u8]) -> Result<i32, AtoiSimdError> {
         parse_fb_checked_neg::<{ i32::MIN as i64 }>(s).map(|v| v as i32)
@@ -110,7 +110,7 @@ impl ParserNeg for i32 {
 }
 
 #[cfg(target_pointer_width = "32")]
-impl ParserPos for usize {
+impl ParsePos for usize {
     #[inline(always)]
     fn atoi_simd_parse_pos(s: &[u8]) -> Result<usize, AtoiSimdError> {
         parse_fb_checked_pos::<{ u32::MAX as u64 }>(s).map(|v| v as usize)
@@ -123,7 +123,7 @@ impl ParserPos for usize {
 }
 
 #[cfg(target_pointer_width = "32")]
-impl ParserPos for isize {
+impl ParsePos for isize {
     #[inline(always)]
     fn atoi_simd_parse_pos(s: &[u8]) -> Result<isize, AtoiSimdError> {
         parse_fb_checked_pos::<{ i32::MAX as u64 }>(s).map(|v| v as isize)
@@ -136,7 +136,7 @@ impl ParserPos for isize {
 }
 
 #[cfg(target_pointer_width = "32")]
-impl ParserNeg for isize {
+impl ParseNeg for isize {
     #[inline(always)]
     fn atoi_simd_parse_neg(s: &[u8]) -> Result<isize, AtoiSimdError> {
         parse_fb_checked_neg::<{ i32::MIN as i64 }>(s).map(|v| v as isize)

--- a/src/linker/fb_64.rs
+++ b/src/linker/fb_64.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::fallback::*;
 
 #[cfg(target_pointer_width = "64")]
-impl ParserPos<usize> for usize {
+impl ParserPos for usize {
     #[inline(always)]
     fn atoi_simd_parse_pos(s: &[u8]) -> Result<usize, AtoiSimdError> {
         parse_fb_checked_64_pos::<{ u64::MAX }, 4>(s).map(|v| v as usize)
@@ -15,7 +15,7 @@ impl ParserPos<usize> for usize {
 }
 
 #[cfg(target_pointer_width = "64")]
-impl ParserPos<isize> for isize {
+impl ParserPos for isize {
     #[inline(always)]
     fn atoi_simd_parse_pos(s: &[u8]) -> Result<isize, AtoiSimdError> {
         parse_fb_checked_64_pos::<{ i64::MAX as u64 }, 3>(s).map(|v| v as isize)
@@ -28,7 +28,7 @@ impl ParserPos<isize> for isize {
 }
 
 #[cfg(target_pointer_width = "64")]
-impl ParserNeg<isize> for isize {
+impl ParserNeg for isize {
     #[inline(always)]
     fn atoi_simd_parse_neg(s: &[u8]) -> Result<isize, AtoiSimdError> {
         parse_fb_checked_64_neg(s).map(|v| v as isize)
@@ -40,7 +40,7 @@ impl ParserNeg<isize> for isize {
     }
 }
 
-impl ParserPos<u64> for u64 {
+impl ParserPos for u64 {
     #[inline(always)]
     fn atoi_simd_parse_pos(s: &[u8]) -> Result<u64, AtoiSimdError> {
         parse_fb_checked_64_pos::<{ u64::MAX }, 4>(s)
@@ -52,7 +52,7 @@ impl ParserPos<u64> for u64 {
     }
 }
 
-impl ParserPos<i64> for i64 {
+impl ParserPos for i64 {
     #[inline(always)]
     fn atoi_simd_parse_pos(s: &[u8]) -> Result<i64, AtoiSimdError> {
         parse_fb_checked_64_pos::<{ i64::MAX as u64 }, 3>(s).map(|v| v as i64)
@@ -64,7 +64,7 @@ impl ParserPos<i64> for i64 {
     }
 }
 
-impl ParserNeg<i64> for i64 {
+impl ParserNeg for i64 {
     #[inline(always)]
     fn atoi_simd_parse_neg(s: &[u8]) -> Result<i64, AtoiSimdError> {
         parse_fb_checked_64_neg(s)
@@ -76,7 +76,7 @@ impl ParserNeg<i64> for i64 {
     }
 }
 
-impl ParserPos<u128> for u128 {
+impl ParserPos for u128 {
     #[inline(always)]
     fn atoi_simd_parse_pos(s: &[u8]) -> Result<u128, AtoiSimdError> {
         parse_fb_checked_128_pos::<{ u128::MAX }>(s)
@@ -88,7 +88,7 @@ impl ParserPos<u128> for u128 {
     }
 }
 
-impl ParserPos<i128> for i128 {
+impl ParserPos for i128 {
     #[inline(always)]
     fn atoi_simd_parse_pos(s: &[u8]) -> Result<i128, AtoiSimdError> {
         parse_fb_checked_128_pos::<{ i128::MAX as u128 }>(s).map(|v| v as i128)
@@ -100,7 +100,7 @@ impl ParserPos<i128> for i128 {
     }
 }
 
-impl ParserNeg<i128> for i128 {
+impl ParserNeg for i128 {
     #[inline(always)]
     fn atoi_simd_parse_neg(s: &[u8]) -> Result<i128, AtoiSimdError> {
         parse_fb_checked_128_neg(s)

--- a/src/linker/fb_64.rs
+++ b/src/linker/fb_64.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::fallback::*;
 
 #[cfg(target_pointer_width = "64")]
-impl ParserPos for usize {
+impl ParsePos for usize {
     #[inline(always)]
     fn atoi_simd_parse_pos(s: &[u8]) -> Result<usize, AtoiSimdError> {
         parse_fb_checked_64_pos::<{ u64::MAX }, 4>(s).map(|v| v as usize)
@@ -15,7 +15,7 @@ impl ParserPos for usize {
 }
 
 #[cfg(target_pointer_width = "64")]
-impl ParserPos for isize {
+impl ParsePos for isize {
     #[inline(always)]
     fn atoi_simd_parse_pos(s: &[u8]) -> Result<isize, AtoiSimdError> {
         parse_fb_checked_64_pos::<{ i64::MAX as u64 }, 3>(s).map(|v| v as isize)
@@ -28,7 +28,7 @@ impl ParserPos for isize {
 }
 
 #[cfg(target_pointer_width = "64")]
-impl ParserNeg for isize {
+impl ParseNeg for isize {
     #[inline(always)]
     fn atoi_simd_parse_neg(s: &[u8]) -> Result<isize, AtoiSimdError> {
         parse_fb_checked_64_neg(s).map(|v| v as isize)
@@ -40,7 +40,7 @@ impl ParserNeg for isize {
     }
 }
 
-impl ParserPos for u64 {
+impl ParsePos for u64 {
     #[inline(always)]
     fn atoi_simd_parse_pos(s: &[u8]) -> Result<u64, AtoiSimdError> {
         parse_fb_checked_64_pos::<{ u64::MAX }, 4>(s)
@@ -52,7 +52,7 @@ impl ParserPos for u64 {
     }
 }
 
-impl ParserPos for i64 {
+impl ParsePos for i64 {
     #[inline(always)]
     fn atoi_simd_parse_pos(s: &[u8]) -> Result<i64, AtoiSimdError> {
         parse_fb_checked_64_pos::<{ i64::MAX as u64 }, 3>(s).map(|v| v as i64)
@@ -64,7 +64,7 @@ impl ParserPos for i64 {
     }
 }
 
-impl ParserNeg for i64 {
+impl ParseNeg for i64 {
     #[inline(always)]
     fn atoi_simd_parse_neg(s: &[u8]) -> Result<i64, AtoiSimdError> {
         parse_fb_checked_64_neg(s)
@@ -76,7 +76,7 @@ impl ParserNeg for i64 {
     }
 }
 
-impl ParserPos for u128 {
+impl ParsePos for u128 {
     #[inline(always)]
     fn atoi_simd_parse_pos(s: &[u8]) -> Result<u128, AtoiSimdError> {
         parse_fb_checked_128_pos::<{ u128::MAX }>(s)
@@ -88,7 +88,7 @@ impl ParserPos for u128 {
     }
 }
 
-impl ParserPos for i128 {
+impl ParsePos for i128 {
     #[inline(always)]
     fn atoi_simd_parse_pos(s: &[u8]) -> Result<i128, AtoiSimdError> {
         parse_fb_checked_128_pos::<{ i128::MAX as u128 }>(s).map(|v| v as i128)
@@ -100,7 +100,7 @@ impl ParserPos for i128 {
     }
 }
 
-impl ParserNeg for i128 {
+impl ParseNeg for i128 {
     #[inline(always)]
     fn atoi_simd_parse_neg(s: &[u8]) -> Result<i128, AtoiSimdError> {
         parse_fb_checked_128_neg(s)

--- a/src/linker/mod.rs
+++ b/src/linker/mod.rs
@@ -46,17 +46,17 @@ mod fb_64;
 
 use crate::{safe_unchecked::SliceGetter, AtoiSimdError};
 
-pub trait ParserPos: Sized {
+pub trait ParsePos: Sized {
     fn atoi_simd_parse_pos(s: &[u8]) -> Result<Self, AtoiSimdError>;
     fn atoi_simd_parse_until_invalid_pos(s: &[u8]) -> Result<(Self, usize), AtoiSimdError>;
 }
 
-pub trait ParserNeg: Sized {
+pub trait ParseNeg: Sized {
     fn atoi_simd_parse_neg(s: &[u8]) -> Result<Self, AtoiSimdError>;
     fn atoi_simd_parse_until_invalid_neg(s: &[u8]) -> Result<(Self, usize), AtoiSimdError>;
 }
 
-pub trait Parser: ParserPos {
+pub trait Parse: ParsePos {
     #[inline(always)]
     fn atoi_simd_parse(s: &[u8]) -> Result<Self, AtoiSimdError> {
         Self::atoi_simd_parse_pos(s)
@@ -83,7 +83,7 @@ pub trait Parser: ParserPos {
 }
 
 #[inline(always)]
-fn atoi_simd_parse_signed<T: ParserPos + ParserNeg>(s: &[u8]) -> Result<T, AtoiSimdError> {
+fn atoi_simd_parse_signed<T: ParsePos + ParseNeg>(s: &[u8]) -> Result<T, AtoiSimdError> {
     if *s.first().ok_or(AtoiSimdError::Empty)? == b'-' {
         T::atoi_simd_parse_neg(s.get_safe_unchecked(1..))
     } else {
@@ -92,7 +92,7 @@ fn atoi_simd_parse_signed<T: ParserPos + ParserNeg>(s: &[u8]) -> Result<T, AtoiS
 }
 
 #[inline(always)]
-fn atoi_simd_parse_until_invalid_signed<T: ParserPos + ParserNeg>(
+fn atoi_simd_parse_until_invalid_signed<T: ParsePos + ParseNeg>(
     s: &[u8],
 ) -> Result<(T, usize), AtoiSimdError> {
     if *s.first().ok_or(AtoiSimdError::Empty)? == b'-' {
@@ -103,7 +103,7 @@ fn atoi_simd_parse_until_invalid_signed<T: ParserPos + ParserNeg>(
 }
 
 #[inline(always)]
-fn atoi_simd_parse_skipped_signed<T: ParserPos + ParserNeg>(
+fn atoi_simd_parse_skipped_signed<T: ParsePos + ParseNeg>(
     s: &[u8],
 ) -> Result<T, AtoiSimdError> {
     let mut neg = false;
@@ -128,12 +128,12 @@ fn atoi_simd_parse_skipped_signed<T: ParserPos + ParserNeg>(
     }
 }
 
-impl Parser for u8 {}
-impl Parser for u16 {}
-impl Parser for u32 {}
-impl Parser for usize {}
-impl Parser for u64 {}
-impl Parser for u128 {}
+impl Parse for u8 {}
+impl Parse for u16 {}
+impl Parse for u32 {}
+impl Parse for usize {}
+impl Parse for u64 {}
+impl Parse for u128 {}
 
 macro_rules! impl_signed {
     () => {
@@ -154,21 +154,21 @@ macro_rules! impl_signed {
     };
 }
 
-impl Parser for i8 {
+impl Parse for i8 {
     impl_signed!();
 }
-impl Parser for i16 {
+impl Parse for i16 {
     impl_signed!();
 }
-impl Parser for i32 {
+impl Parse for i32 {
     impl_signed!();
 }
-impl Parser for isize {
+impl Parse for isize {
     impl_signed!();
 }
-impl Parser for i64 {
+impl Parse for i64 {
     impl_signed!();
 }
-impl Parser for i128 {
+impl Parse for i128 {
     impl_signed!();
 }

--- a/src/linker/mod.rs
+++ b/src/linker/mod.rs
@@ -46,29 +46,29 @@ mod fb_64;
 
 use crate::{safe_unchecked::SliceGetter, AtoiSimdError};
 
-pub trait ParserPos<T>: Sized {
-    fn atoi_simd_parse_pos(s: &[u8]) -> Result<T, AtoiSimdError>;
-    fn atoi_simd_parse_until_invalid_pos(s: &[u8]) -> Result<(T, usize), AtoiSimdError>;
+pub trait ParserPos: Sized {
+    fn atoi_simd_parse_pos(s: &[u8]) -> Result<Self, AtoiSimdError>;
+    fn atoi_simd_parse_until_invalid_pos(s: &[u8]) -> Result<(Self, usize), AtoiSimdError>;
 }
 
-pub trait ParserNeg<T>: Sized {
-    fn atoi_simd_parse_neg(s: &[u8]) -> Result<T, AtoiSimdError>;
-    fn atoi_simd_parse_until_invalid_neg(s: &[u8]) -> Result<(T, usize), AtoiSimdError>;
+pub trait ParserNeg: Sized {
+    fn atoi_simd_parse_neg(s: &[u8]) -> Result<Self, AtoiSimdError>;
+    fn atoi_simd_parse_until_invalid_neg(s: &[u8]) -> Result<(Self, usize), AtoiSimdError>;
 }
 
-pub trait Parser<T: ParserPos<T>>: Sized {
+pub trait Parser: ParserPos {
     #[inline(always)]
-    fn atoi_simd_parse(s: &[u8]) -> Result<T, AtoiSimdError> {
-        T::atoi_simd_parse_pos(s)
+    fn atoi_simd_parse(s: &[u8]) -> Result<Self, AtoiSimdError> {
+        Self::atoi_simd_parse_pos(s)
     }
 
     #[inline(always)]
-    fn atoi_simd_parse_until_invalid(s: &[u8]) -> Result<(T, usize), AtoiSimdError> {
-        T::atoi_simd_parse_until_invalid_pos(s)
+    fn atoi_simd_parse_until_invalid(s: &[u8]) -> Result<(Self, usize), AtoiSimdError> {
+        Self::atoi_simd_parse_until_invalid_pos(s)
     }
 
     #[inline(always)]
-    fn atoi_simd_parse_skipped(s: &[u8]) -> Result<T, AtoiSimdError> {
+    fn atoi_simd_parse_skipped(s: &[u8]) -> Result<Self, AtoiSimdError> {
         let mut i = 0;
         if *s.first().ok_or(AtoiSimdError::Empty)? == b'+' {
             i = 1;
@@ -78,12 +78,12 @@ pub trait Parser<T: ParserPos<T>>: Sized {
             i += 1;
         }
 
-        T::atoi_simd_parse_pos(s.get_safe_unchecked(i..))
+        Self::atoi_simd_parse_pos(s.get_safe_unchecked(i..))
     }
 }
 
 #[inline(always)]
-fn atoi_simd_parse_signed<T: ParserPos<T> + ParserNeg<T>>(s: &[u8]) -> Result<T, AtoiSimdError> {
+fn atoi_simd_parse_signed<T: ParserPos + ParserNeg>(s: &[u8]) -> Result<T, AtoiSimdError> {
     if *s.first().ok_or(AtoiSimdError::Empty)? == b'-' {
         T::atoi_simd_parse_neg(s.get_safe_unchecked(1..))
     } else {
@@ -92,7 +92,7 @@ fn atoi_simd_parse_signed<T: ParserPos<T> + ParserNeg<T>>(s: &[u8]) -> Result<T,
 }
 
 #[inline(always)]
-fn atoi_simd_parse_until_invalid_signed<T: ParserPos<T> + ParserNeg<T>>(
+fn atoi_simd_parse_until_invalid_signed<T: ParserPos + ParserNeg>(
     s: &[u8],
 ) -> Result<(T, usize), AtoiSimdError> {
     if *s.first().ok_or(AtoiSimdError::Empty)? == b'-' {
@@ -103,7 +103,7 @@ fn atoi_simd_parse_until_invalid_signed<T: ParserPos<T> + ParserNeg<T>>(
 }
 
 #[inline(always)]
-fn atoi_simd_parse_skipped_signed<T: ParserPos<T> + ParserNeg<T>>(
+fn atoi_simd_parse_skipped_signed<T: ParserPos + ParserNeg>(
     s: &[u8],
 ) -> Result<T, AtoiSimdError> {
     let mut neg = false;
@@ -128,12 +128,12 @@ fn atoi_simd_parse_skipped_signed<T: ParserPos<T> + ParserNeg<T>>(
     }
 }
 
-impl Parser<u8> for u8 {}
-impl Parser<u16> for u16 {}
-impl Parser<u32> for u32 {}
-impl Parser<usize> for usize {}
-impl Parser<u64> for u64 {}
-impl Parser<u128> for u128 {}
+impl Parser for u8 {}
+impl Parser for u16 {}
+impl Parser for u32 {}
+impl Parser for usize {}
+impl Parser for u64 {}
+impl Parser for u128 {}
 
 macro_rules! impl_signed {
     () => {
@@ -154,21 +154,21 @@ macro_rules! impl_signed {
     };
 }
 
-impl Parser<i8> for i8 {
+impl Parser for i8 {
     impl_signed!();
 }
-impl Parser<i16> for i16 {
+impl Parser for i16 {
     impl_signed!();
 }
-impl Parser<i32> for i32 {
+impl Parser for i32 {
     impl_signed!();
 }
-impl Parser<isize> for isize {
+impl Parser for isize {
     impl_signed!();
 }
-impl Parser<i64> for i64 {
+impl Parser for i64 {
     impl_signed!();
 }
-impl Parser<i128> for i128 {
+impl Parser for i128 {
     impl_signed!();
 }

--- a/src/linker/mod.rs
+++ b/src/linker/mod.rs
@@ -103,9 +103,7 @@ fn atoi_simd_parse_until_invalid_signed<T: ParsePos + ParseNeg>(
 }
 
 #[inline(always)]
-fn atoi_simd_parse_skipped_signed<T: ParsePos + ParseNeg>(
-    s: &[u8],
-) -> Result<T, AtoiSimdError> {
+fn atoi_simd_parse_skipped_signed<T: ParsePos + ParseNeg>(s: &[u8]) -> Result<T, AtoiSimdError> {
     let mut neg = false;
     let mut i = match *s.first().ok_or(AtoiSimdError::Empty)? {
         b'+' => 1,

--- a/src/linker/mod.rs
+++ b/src/linker/mod.rs
@@ -135,40 +135,25 @@ impl Parse for usize {}
 impl Parse for u64 {}
 impl Parse for u128 {}
 
-macro_rules! impl_signed {
-    () => {
-        #[inline(always)]
-        fn atoi_simd_parse(s: &[u8]) -> Result<Self, AtoiSimdError> {
-            atoi_simd_parse_signed(s)
-        }
+macro_rules! parse_impl_signed {
+    ($($t:ty)*) => {$(
+        impl Parse for $t {
+            #[inline(always)]
+            fn atoi_simd_parse(s: &[u8]) -> Result<Self, AtoiSimdError> {
+                atoi_simd_parse_signed(s)
+            }
 
-        #[inline(always)]
-        fn atoi_simd_parse_until_invalid(s: &[u8]) -> Result<(Self, usize), AtoiSimdError> {
-            atoi_simd_parse_until_invalid_signed(s)
-        }
+            #[inline(always)]
+            fn atoi_simd_parse_until_invalid(s: &[u8]) -> Result<(Self, usize), AtoiSimdError> {
+                atoi_simd_parse_until_invalid_signed(s)
+            }
 
-        #[inline(always)]
-        fn atoi_simd_parse_skipped(s: &[u8]) -> Result<Self, AtoiSimdError> {
-            atoi_simd_parse_skipped_signed(s)
+            #[inline(always)]
+            fn atoi_simd_parse_skipped(s: &[u8]) -> Result<Self, AtoiSimdError> {
+                atoi_simd_parse_skipped_signed(s)
+            }
         }
-    };
+    )*};
 }
 
-impl Parse for i8 {
-    impl_signed!();
-}
-impl Parse for i16 {
-    impl_signed!();
-}
-impl Parse for i32 {
-    impl_signed!();
-}
-impl Parse for isize {
-    impl_signed!();
-}
-impl Parse for i64 {
-    impl_signed!();
-}
-impl Parse for i128 {
-    impl_signed!();
-}
+parse_impl_signed!(i8 i16 i32 isize i64 i128);

--- a/src/linker/simd_32.rs
+++ b/src/linker/simd_32.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::simd::shared_32::*;
 
-impl ParserPos for u8 {
+impl ParsePos for u8 {
     #[inline(always)]
     fn atoi_simd_parse_pos(s: &[u8]) -> Result<u8, AtoiSimdError> {
         parse_simd_checked::<{ u8::MAX as u64 }>(s).map(|v| v as u8)
@@ -13,7 +13,7 @@ impl ParserPos for u8 {
     }
 }
 
-impl ParserPos for i8 {
+impl ParsePos for i8 {
     #[inline(always)]
     fn atoi_simd_parse_pos(s: &[u8]) -> Result<i8, AtoiSimdError> {
         parse_simd_checked::<{ i8::MAX as u64 }>(s).map(|v| v as i8)
@@ -25,7 +25,7 @@ impl ParserPos for i8 {
     }
 }
 
-impl ParserNeg for i8 {
+impl ParseNeg for i8 {
     #[inline(always)]
     fn atoi_simd_parse_neg(s: &[u8]) -> Result<i8, AtoiSimdError> {
         parse_simd_checked_neg::<{ i8::MIN as i64 }>(s).map(|v| v as i8)
@@ -37,7 +37,7 @@ impl ParserNeg for i8 {
     }
 }
 
-impl ParserPos for u16 {
+impl ParsePos for u16 {
     #[inline(always)]
     fn atoi_simd_parse_pos(s: &[u8]) -> Result<u16, AtoiSimdError> {
         parse_simd_checked::<{ u16::MAX as u64 }>(s).map(|v| v as u16)
@@ -49,7 +49,7 @@ impl ParserPos for u16 {
     }
 }
 
-impl ParserPos for i16 {
+impl ParsePos for i16 {
     #[inline(always)]
     fn atoi_simd_parse_pos(s: &[u8]) -> Result<i16, AtoiSimdError> {
         parse_simd_checked::<{ i16::MAX as u64 }>(s).map(|v| v as i16)
@@ -61,7 +61,7 @@ impl ParserPos for i16 {
     }
 }
 
-impl ParserNeg for i16 {
+impl ParseNeg for i16 {
     #[inline(always)]
     fn atoi_simd_parse_neg(s: &[u8]) -> Result<i16, AtoiSimdError> {
         parse_simd_checked_neg::<{ i16::MIN as i64 }>(s).map(|v| v as i16)
@@ -73,7 +73,7 @@ impl ParserNeg for i16 {
     }
 }
 
-impl ParserPos for u32 {
+impl ParsePos for u32 {
     #[inline(always)]
     fn atoi_simd_parse_pos(s: &[u8]) -> Result<u32, AtoiSimdError> {
         parse_simd_checked::<{ u32::MAX as u64 }>(s).map(|v| v as u32)
@@ -85,7 +85,7 @@ impl ParserPos for u32 {
     }
 }
 
-impl ParserPos for i32 {
+impl ParsePos for i32 {
     #[inline(always)]
     fn atoi_simd_parse_pos(s: &[u8]) -> Result<i32, AtoiSimdError> {
         parse_simd_checked::<{ i32::MAX as u64 }>(s).map(|v| v as i32)
@@ -97,7 +97,7 @@ impl ParserPos for i32 {
     }
 }
 
-impl ParserNeg for i32 {
+impl ParseNeg for i32 {
     #[inline(always)]
     fn atoi_simd_parse_neg(s: &[u8]) -> Result<i32, AtoiSimdError> {
         parse_simd_checked_neg::<{ i32::MIN as i64 }>(s).map(|v| v as i32)
@@ -110,7 +110,7 @@ impl ParserNeg for i32 {
 }
 
 #[cfg(target_pointer_width = "32")]
-impl ParserPos for usize {
+impl ParsePos for usize {
     #[inline(always)]
     fn atoi_simd_parse_pos(s: &[u8]) -> Result<usize, AtoiSimdError> {
         parse_simd_checked::<{ u32::MAX as u64 }>(s).map(|v| v as usize)
@@ -123,7 +123,7 @@ impl ParserPos for usize {
 }
 
 #[cfg(target_pointer_width = "32")]
-impl ParserPos for isize {
+impl ParsePos for isize {
     #[inline(always)]
     fn atoi_simd_parse_pos(s: &[u8]) -> Result<isize, AtoiSimdError> {
         parse_simd_checked::<{ i32::MAX as u64 }>(s).map(|v| v as isize)
@@ -136,7 +136,7 @@ impl ParserPos for isize {
 }
 
 #[cfg(target_pointer_width = "32")]
-impl ParserNeg for isize {
+impl ParseNeg for isize {
     #[inline(always)]
     fn atoi_simd_parse_neg(s: &[u8]) -> Result<isize, AtoiSimdError> {
         parse_simd_checked_neg::<{ i32::MIN as i64 }>(s).map(|v| v as isize)

--- a/src/linker/simd_32.rs
+++ b/src/linker/simd_32.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::simd::shared_32::*;
 
-impl ParserPos<u8> for u8 {
+impl ParserPos for u8 {
     #[inline(always)]
     fn atoi_simd_parse_pos(s: &[u8]) -> Result<u8, AtoiSimdError> {
         parse_simd_checked::<{ u8::MAX as u64 }>(s).map(|v| v as u8)
@@ -13,7 +13,7 @@ impl ParserPos<u8> for u8 {
     }
 }
 
-impl ParserPos<i8> for i8 {
+impl ParserPos for i8 {
     #[inline(always)]
     fn atoi_simd_parse_pos(s: &[u8]) -> Result<i8, AtoiSimdError> {
         parse_simd_checked::<{ i8::MAX as u64 }>(s).map(|v| v as i8)
@@ -25,7 +25,7 @@ impl ParserPos<i8> for i8 {
     }
 }
 
-impl ParserNeg<i8> for i8 {
+impl ParserNeg for i8 {
     #[inline(always)]
     fn atoi_simd_parse_neg(s: &[u8]) -> Result<i8, AtoiSimdError> {
         parse_simd_checked_neg::<{ i8::MIN as i64 }>(s).map(|v| v as i8)
@@ -37,7 +37,7 @@ impl ParserNeg<i8> for i8 {
     }
 }
 
-impl ParserPos<u16> for u16 {
+impl ParserPos for u16 {
     #[inline(always)]
     fn atoi_simd_parse_pos(s: &[u8]) -> Result<u16, AtoiSimdError> {
         parse_simd_checked::<{ u16::MAX as u64 }>(s).map(|v| v as u16)
@@ -49,7 +49,7 @@ impl ParserPos<u16> for u16 {
     }
 }
 
-impl ParserPos<i16> for i16 {
+impl ParserPos for i16 {
     #[inline(always)]
     fn atoi_simd_parse_pos(s: &[u8]) -> Result<i16, AtoiSimdError> {
         parse_simd_checked::<{ i16::MAX as u64 }>(s).map(|v| v as i16)
@@ -61,7 +61,7 @@ impl ParserPos<i16> for i16 {
     }
 }
 
-impl ParserNeg<i16> for i16 {
+impl ParserNeg for i16 {
     #[inline(always)]
     fn atoi_simd_parse_neg(s: &[u8]) -> Result<i16, AtoiSimdError> {
         parse_simd_checked_neg::<{ i16::MIN as i64 }>(s).map(|v| v as i16)
@@ -73,7 +73,7 @@ impl ParserNeg<i16> for i16 {
     }
 }
 
-impl ParserPos<u32> for u32 {
+impl ParserPos for u32 {
     #[inline(always)]
     fn atoi_simd_parse_pos(s: &[u8]) -> Result<u32, AtoiSimdError> {
         parse_simd_checked::<{ u32::MAX as u64 }>(s).map(|v| v as u32)
@@ -85,7 +85,7 @@ impl ParserPos<u32> for u32 {
     }
 }
 
-impl ParserPos<i32> for i32 {
+impl ParserPos for i32 {
     #[inline(always)]
     fn atoi_simd_parse_pos(s: &[u8]) -> Result<i32, AtoiSimdError> {
         parse_simd_checked::<{ i32::MAX as u64 }>(s).map(|v| v as i32)
@@ -97,7 +97,7 @@ impl ParserPos<i32> for i32 {
     }
 }
 
-impl ParserNeg<i32> for i32 {
+impl ParserNeg for i32 {
     #[inline(always)]
     fn atoi_simd_parse_neg(s: &[u8]) -> Result<i32, AtoiSimdError> {
         parse_simd_checked_neg::<{ i32::MIN as i64 }>(s).map(|v| v as i32)
@@ -110,7 +110,7 @@ impl ParserNeg<i32> for i32 {
 }
 
 #[cfg(target_pointer_width = "32")]
-impl ParserPos<usize> for usize {
+impl ParserPos for usize {
     #[inline(always)]
     fn atoi_simd_parse_pos(s: &[u8]) -> Result<usize, AtoiSimdError> {
         parse_simd_checked::<{ u32::MAX as u64 }>(s).map(|v| v as usize)
@@ -123,7 +123,7 @@ impl ParserPos<usize> for usize {
 }
 
 #[cfg(target_pointer_width = "32")]
-impl ParserPos<isize> for isize {
+impl ParserPos for isize {
     #[inline(always)]
     fn atoi_simd_parse_pos(s: &[u8]) -> Result<isize, AtoiSimdError> {
         parse_simd_checked::<{ i32::MAX as u64 }>(s).map(|v| v as isize)
@@ -136,7 +136,7 @@ impl ParserPos<isize> for isize {
 }
 
 #[cfg(target_pointer_width = "32")]
-impl ParserNeg<isize> for isize {
+impl ParserNeg for isize {
     #[inline(always)]
     fn atoi_simd_parse_neg(s: &[u8]) -> Result<isize, AtoiSimdError> {
         parse_simd_checked_neg::<{ i32::MIN as i64 }>(s).map(|v| v as isize)

--- a/src/linker/simd_64.rs
+++ b/src/linker/simd_64.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::simd::shared_64::*;
 
 #[cfg(target_pointer_width = "64")]
-impl ParserPos<usize> for usize {
+impl ParserPos for usize {
     #[inline(always)]
     fn atoi_simd_parse_pos(s: &[u8]) -> Result<usize, AtoiSimdError> {
         parse_simd_checked_u64(s).map(|v| v as usize)
@@ -15,7 +15,7 @@ impl ParserPos<usize> for usize {
 }
 
 #[cfg(target_pointer_width = "64")]
-impl ParserPos<isize> for isize {
+impl ParserPos for isize {
     #[inline(always)]
     fn atoi_simd_parse_pos(s: &[u8]) -> Result<isize, AtoiSimdError> {
         parse_simd_checked_i64(s).map(|v| v as isize)
@@ -28,7 +28,7 @@ impl ParserPos<isize> for isize {
 }
 
 #[cfg(target_pointer_width = "64")]
-impl ParserNeg<isize> for isize {
+impl ParserNeg for isize {
     #[inline(always)]
     fn atoi_simd_parse_neg(s: &[u8]) -> Result<isize, AtoiSimdError> {
         parse_simd_checked_i64_neg(s).map(|v| v as isize)
@@ -40,7 +40,7 @@ impl ParserNeg<isize> for isize {
     }
 }
 
-impl ParserPos<u64> for u64 {
+impl ParserPos for u64 {
     #[inline(always)]
     fn atoi_simd_parse_pos(s: &[u8]) -> Result<u64, AtoiSimdError> {
         parse_simd_checked_u64(s)
@@ -52,7 +52,7 @@ impl ParserPos<u64> for u64 {
     }
 }
 
-impl ParserPos<i64> for i64 {
+impl ParserPos for i64 {
     #[inline(always)]
     fn atoi_simd_parse_pos(s: &[u8]) -> Result<i64, AtoiSimdError> {
         parse_simd_checked_i64(s)
@@ -64,7 +64,7 @@ impl ParserPos<i64> for i64 {
     }
 }
 
-impl ParserNeg<i64> for i64 {
+impl ParserNeg for i64 {
     #[inline(always)]
     fn atoi_simd_parse_neg(s: &[u8]) -> Result<i64, AtoiSimdError> {
         parse_simd_checked_i64_neg(s)
@@ -76,7 +76,7 @@ impl ParserNeg<i64> for i64 {
     }
 }
 
-impl ParserPos<u128> for u128 {
+impl ParserPos for u128 {
     #[inline(always)]
     fn atoi_simd_parse_pos(s: &[u8]) -> Result<u128, AtoiSimdError> {
         parse_simd_checked_u128(s)
@@ -88,7 +88,7 @@ impl ParserPos<u128> for u128 {
     }
 }
 
-impl ParserPos<i128> for i128 {
+impl ParserPos for i128 {
     #[inline(always)]
     fn atoi_simd_parse_pos(s: &[u8]) -> Result<i128, AtoiSimdError> {
         parse_simd_checked_i128(s)
@@ -100,7 +100,7 @@ impl ParserPos<i128> for i128 {
     }
 }
 
-impl ParserNeg<i128> for i128 {
+impl ParserNeg for i128 {
     #[inline(always)]
     fn atoi_simd_parse_neg(s: &[u8]) -> Result<i128, AtoiSimdError> {
         parse_simd_checked_i128_neg(s)

--- a/src/linker/simd_64.rs
+++ b/src/linker/simd_64.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::simd::shared_64::*;
 
 #[cfg(target_pointer_width = "64")]
-impl ParserPos for usize {
+impl ParsePos for usize {
     #[inline(always)]
     fn atoi_simd_parse_pos(s: &[u8]) -> Result<usize, AtoiSimdError> {
         parse_simd_checked_u64(s).map(|v| v as usize)
@@ -15,7 +15,7 @@ impl ParserPos for usize {
 }
 
 #[cfg(target_pointer_width = "64")]
-impl ParserPos for isize {
+impl ParsePos for isize {
     #[inline(always)]
     fn atoi_simd_parse_pos(s: &[u8]) -> Result<isize, AtoiSimdError> {
         parse_simd_checked_i64(s).map(|v| v as isize)
@@ -28,7 +28,7 @@ impl ParserPos for isize {
 }
 
 #[cfg(target_pointer_width = "64")]
-impl ParserNeg for isize {
+impl ParseNeg for isize {
     #[inline(always)]
     fn atoi_simd_parse_neg(s: &[u8]) -> Result<isize, AtoiSimdError> {
         parse_simd_checked_i64_neg(s).map(|v| v as isize)
@@ -40,7 +40,7 @@ impl ParserNeg for isize {
     }
 }
 
-impl ParserPos for u64 {
+impl ParsePos for u64 {
     #[inline(always)]
     fn atoi_simd_parse_pos(s: &[u8]) -> Result<u64, AtoiSimdError> {
         parse_simd_checked_u64(s)
@@ -52,7 +52,7 @@ impl ParserPos for u64 {
     }
 }
 
-impl ParserPos for i64 {
+impl ParsePos for i64 {
     #[inline(always)]
     fn atoi_simd_parse_pos(s: &[u8]) -> Result<i64, AtoiSimdError> {
         parse_simd_checked_i64(s)
@@ -64,7 +64,7 @@ impl ParserPos for i64 {
     }
 }
 
-impl ParserNeg for i64 {
+impl ParseNeg for i64 {
     #[inline(always)]
     fn atoi_simd_parse_neg(s: &[u8]) -> Result<i64, AtoiSimdError> {
         parse_simd_checked_i64_neg(s)
@@ -76,7 +76,7 @@ impl ParserNeg for i64 {
     }
 }
 
-impl ParserPos for u128 {
+impl ParsePos for u128 {
     #[inline(always)]
     fn atoi_simd_parse_pos(s: &[u8]) -> Result<u128, AtoiSimdError> {
         parse_simd_checked_u128(s)
@@ -88,7 +88,7 @@ impl ParserPos for u128 {
     }
 }
 
-impl ParserPos for i128 {
+impl ParsePos for i128 {
     #[inline(always)]
     fn atoi_simd_parse_pos(s: &[u8]) -> Result<i128, AtoiSimdError> {
         parse_simd_checked_i128(s)
@@ -100,7 +100,7 @@ impl ParserPos for i128 {
     }
 }
 
-impl ParserNeg for i128 {
+impl ParseNeg for i128 {
     #[inline(always)]
     fn atoi_simd_parse_neg(s: &[u8]) -> Result<i128, AtoiSimdError> {
         parse_simd_checked_i128_neg(s)

--- a/src/test.rs
+++ b/src/test.rs
@@ -87,7 +87,7 @@ fn test_each_position_until_invalid<T: Copy + Debug + PartialEq + FromStr>(
 }
 
 fn parse_tester<
-    T: Copy + Debug + PartialEq + FromStr + Parser + ParserPos,
+    T: Copy + Debug + PartialEq + FromStr + Parse + ParsePos,
     const LEN: usize,
     const LEN_NEG: usize,
     I,
@@ -118,7 +118,7 @@ fn parse_tester<
 }
 
 fn parse_until_invalid_tester<
-    T: Copy + Debug + PartialEq + FromStr + Parser + ParserPos,
+    T: Copy + Debug + PartialEq + FromStr + Parse + ParsePos,
     const LEN: usize,
     const LEN_NEG: usize,
     I,

--- a/src/test.rs
+++ b/src/test.rs
@@ -87,7 +87,7 @@ fn test_each_position_until_invalid<T: Copy + Debug + PartialEq + FromStr>(
 }
 
 fn parse_tester<
-    T: Copy + Debug + PartialEq + FromStr + Parser<T> + ParserPos<T>,
+    T: Copy + Debug + PartialEq + FromStr + Parser + ParserPos,
     const LEN: usize,
     const LEN_NEG: usize,
     I,
@@ -118,7 +118,7 @@ fn parse_tester<
 }
 
 fn parse_until_invalid_tester<
-    T: Copy + Debug + PartialEq + FromStr + Parser<T> + ParserPos<T>,
+    T: Copy + Debug + PartialEq + FromStr + Parser + ParserPos,
     const LEN: usize,
     const LEN_NEG: usize,
     I,

--- a/src/test.rs
+++ b/src/test.rs
@@ -87,7 +87,7 @@ fn test_each_position_until_invalid<T: Copy + Debug + PartialEq + FromStr>(
 }
 
 fn parse_tester<
-    T: Copy + Debug + PartialEq + FromStr + Parse + ParsePos,
+    T: Copy + Debug + PartialEq + FromStr + Parse,
     const LEN: usize,
     const LEN_NEG: usize,
     I,
@@ -118,7 +118,7 @@ fn parse_tester<
 }
 
 fn parse_until_invalid_tester<
-    T: Copy + Debug + PartialEq + FromStr + Parse + ParsePos,
+    T: Copy + Debug + PartialEq + FromStr + Parse,
     const LEN: usize,
     const LEN_NEG: usize,
     I,


### PR DESCRIPTION
Hi there, I’ve been noticing the weird-looking trait bounds appearing on the public API, such as `pub fn parse<T: Parser<T> + ParserPos<T>>`.

The trait’s type parameters aren’t actually necessary. Perhaps they were used because the author didn’t realize they could achieve the default implementations for `Parse`, which used to rely on a trait bound in the argument, `trait Parser<T: ParserPos<T>>`, by using a supertrait bound instead.

Anyways, this PR contains multiple commits, starting off with

* removal of the redundant generic argument on `Parser`, `ParserPos`, `ParserNeg`
  * so it’d be  `pub fn parse<T: Parser + ParserPos>` then
* renaming of these traits to use “parse” instead of “parser” – this will look a lot more fitting in the documentation, in my opinion
  * so it’d be  `pub fn parse<T: Parse + ParsePos>` then
* simplification of the bounds, another thing that becomes possibly with the supertrait bound `trait Parse: ParsePos`
  * so it’d be  `pub fn parse<T: Parse>` then
* using only `Parse` and `ParseNeg`, no longer `ParsePos`, in public API. The set of types implementing `Parse` and `ParsePos` seems to be identical. (Please comment if this observation is wrong under any cfgs, or is intended to become wrong in the future.)
  * this turns e.g. `pub fn parse_pos<T: ParsePos>` into `pub fn parse_pos<T: Parse>` 
* I could not help but stumble over the `impl_signed` macro, which I felt was more tidy if the `impl` was created by the macro fully, which also stylistically follows common precedent [in `std`](https://doc.rust-lang.org/1.74.1/src/core/ops/arith.rs.html#94-109) – sorry this is relatively unrelated to the main refactor here, but it’s still something about the `Parse`[`r`] trait I’ve come across

Feel free to give feedback in case you’re interested in merging only part of these changes.